### PR TITLE
adds manage alias

### DIFF
--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -41,7 +41,7 @@ app_setup_block_enabled: true
 app_setup_block: |
   Default login is admin:admin via the webui, accessible at http://SERVERIP:PORT
   More info at [paperless-ng]({{ project_url }}).
-  For convenience this container provides an alias to perform administration management commands. Available administration commands are documented upstream [here](https://paperless-ng.readthedocs.io/en/latest/administration.html) and can access with this container thus: `docker exec -it <container_name> manage <command>`. For example, `docker exec -it paperless manage  document_retagger -tT`. 
+  For convenience this container provides an alias to perform administration management commands. Available administration commands are documented upstream [here](https://paperless-ng.readthedocs.io/en/latest/administration.html) and can be accessed with this container thus: `docker exec -it <container_name> manage <command>`. For example, `docker exec -it paperless manage  document_retagger -tT`. 
 # changelog
 changelogs:
   - { date: "24.07.21:", desc: "Fixed directory config files (sqlite db) is all stored." }

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -41,6 +41,7 @@ app_setup_block_enabled: true
 app_setup_block: |
   Default login is admin:admin via the webui, accessible at http://SERVERIP:PORT
   More info at [paperless-ng]({{ project_url }}).
+  For convenience this container provides an alias to perform administration management commands. Available administration commands are documented upstream [here](https://paperless-ng.readthedocs.io/en/latest/administration.html) and can access with this container thus: `docker exec -it <container_name> manage <command>`. For example, `docker exec -it paperless manage  document_retagger -tT`. 
 # changelog
 changelogs:
   - { date: "24.07.21:", desc: "Fixed directory config files (sqlite db) is all stored." }

--- a/root/etc/cont-init.d/70-aliases
+++ b/root/etc/cont-init.d/70-aliases
@@ -1,0 +1,10 @@
+#!/usr/bin/with-contenv bash
+# for convenience use this manage alias like so `docker exec -it paperless manage <command>`
+# https://paperless-ng.readthedocs.io/en/latest/administration.html
+
+## set alias for manage.py
+[[ ! -f /usr/local/bin/manage ]] && \
+  echo -e '#!/bin/bash\n/usr/bin/python3 /app/paperless/src/manage.py' > /usr/local/bin/manage
+
+[[ ! -x /usr/local/bin/manage ]] && \
+  chmod +x /usr/local/bin/manage

--- a/root/etc/cont-init.d/70-aliases
+++ b/root/etc/cont-init.d/70-aliases
@@ -4,7 +4,7 @@
 
 ## set alias for manage.py
 [[ ! -f /usr/local/bin/manage ]] && \
-  echo -e '#!/bin/bash\n/usr/bin/python3 /app/paperless/src/manage.py' > /usr/local/bin/manage
+  echo -e '#!/bin/bash\n/usr/bin/python3 /app/paperless/src/manage.py $*' > /usr/local/bin/manage
 
 [[ ! -x /usr/local/bin/manage ]] && \
   chmod +x /usr/local/bin/manage


### PR DESCRIPTION
Adds an alias for simpler management of built-in administration commands via `docker exec -it paperless manage <command>`.

Example output [here](https://gist.github.com/IronicBadger/9bf7e96f5719975b409fa58b09ddfd76).

Available commands are documented here - https://paperless-ng.readthedocs.io/en/latest/administration.html.

Not sure if you want a small update to the README to reflect this or not.